### PR TITLE
adding import tradingview_ta

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,6 +11,7 @@ Importing TradingView_TA
 .. code-block:: python3
 
     from tradingview_ta import TA_Handler, Interval, Exchange
+    import tradingview_ta
 
 
 Checking the version


### PR DESCRIPTION
The line `print(tradingview_ta.__version__)` in the next section ("Checking the version") only works if tradingview_ta itself is imported (importing TA_Handler, Interval & Exchange from tradingview_ta won't cut it).